### PR TITLE
fix: Don't parse policies that are empty strings

### DIFF
--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -5,7 +5,7 @@
  * @returns the parsed JSON object, or undefined if value is undefined
  */
 export function parseIfPresent(value: string | undefined): any {
-  if (value === undefined) {
+  if (value === undefined || value === null || value.trim() === '') {
     return undefined
   }
   return JSON.parse(value)


### PR DESCRIPTION
This should address number #233 