### PR TITLE
chore: use shared dependency update action

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,6 +7,7 @@ on:
       - edited
       - synchronize
       - reopened
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -15,6 +16,7 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target'
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:
@@ -27,7 +29,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -47,7 +49,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -73,7 +75,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Set up Python

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -9,8 +9,12 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Push branches
-      pull-requests: write # Create PRs
+      contents: write # Push branches, merge PRs, delete branches
+      pull-requests: write # Create and merge PRs
+      actions: write # Run check workflows
     steps:
       - name: Run dependency update
-        uses: cloud-copilot/update-dependencies@main
+        uses: cloud-copilot/action-update-dependencies@fe48d42724df9c4ed34abf9c0cc97a8da42917f4
+        with:
+          check-workflow: pr-checks.yml
+          post-merge-workflow: release.yml


### PR DESCRIPTION
## Summary
- switch the dependency update workflow to `cloud-copilot/action-update-dependencies` pinned at `fe48d42724df9c4ed34abf9c0cc97a8da42917f4`
- grant `actions: write` so the updater can dispatch check and release workflows
- allow `pr-checks.yml` to run via `workflow_dispatch` and checkout the dispatched branch SHA
- dispatch `release.yml` after successful dependency update merges

## Testing
- Parsed updated workflow YAML files locally with Ruby YAML loader