### PR TITLE
fix: handle wildcard region in sqlite metadata lookup

### DIFF
--- a/src/persistence/sqlite/SqliteAwsIamStore.test.ts
+++ b/src/persistence/sqlite/SqliteAwsIamStore.test.ts
@@ -316,6 +316,22 @@ describe('SqliteAwsIamStore', () => {
       )
       expect(result).toEqual([])
     })
+
+    it("findResourceMetadata treats region '*' as any region", async () => {
+      const anyRegion = await store.findResourceMetadata<{ name: string }>('123456789012', {
+        service: 'lambda',
+        region: '*',
+        resourceType: 'function'
+      })
+      expect(anyRegion.map((resource) => resource.name)).toEqual(['test'])
+
+      const wrongRegion = await store.findResourceMetadata<{ name: string }>('123456789012', {
+        service: 'lambda',
+        region: 'eu-west-1',
+        resourceType: 'function'
+      })
+      expect(wrongRegion).toEqual([])
+    })
   })
 
   describe('Resource Sync', () => {

--- a/src/persistence/sqlite/SqliteAwsIamStore.ts
+++ b/src/persistence/sqlite/SqliteAwsIamStore.ts
@@ -244,7 +244,7 @@ export class SqliteAwsIamStore implements AwsIamStore {
   async findResourceMetadata<T>(accountId: string, options: ResourceTypeParts): Promise<T[]> {
     accountId = accountId.toLowerCase()
     let sql = `SELECT data FROM resource_metadata WHERE partition=${quote(this.partition)} AND account_id=${quote(accountId)} AND service=${quote(options.service.toLowerCase())} AND metadata_type='metadata'`
-    if (options.region) {
+    if (options.region && options.region !== '*') {
       sql += ` AND region=${quote(options.region.toLowerCase())}`
     }
     if (options.resourceType) {


### PR DESCRIPTION
## Summary

SQLite-backed resource metadata lookups now treat `region: '*'` as a wildcard region for `findResourceMetadata`, matching the file-backed store behavior used by indexers. This allows all-region index updates to find resources stored with concrete ARN-derived regions without changing `listResources` semantics.
