### PR TITLE
feat: collect organization s3 policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ If you prefer, you can configure iam-collect to pull data from AWS Config instea
 | organizations     | Organizations                     | id, root account id, enabled policy types, org structure, delegated administrators                                                  |
 | organizations     | Organizational Units              | id, parent ou, enabled SCPs, enabled RCPs, tags                                                                                     |
 | organizations     | Accounts                          | id, parent ou, enabled SCPs, enabled RCPs, tags                                                                                     |
-| organizations     | SCPs, RCPs                        | id, name, description, tags, policy                                                                                                 |
+| organizations     | SCPs, RCPs, S3 Policies           | id, name, description, tags, policy                                                                                                 |
 | sns               | Topics                            | name, tags, kms key id, policy                                                                                                      |
 | sqs               | Queues                            | name, tags, kms key id, policy                                                                                                      |
 | secretsmanager    | Secrets                           | name, tags, kms key id, policy                                                                                                      |

--- a/docs/Storage.md
+++ b/docs/Storage.md
@@ -105,6 +105,7 @@ aws/                                          # always `aws` for now, may add ot
     │   └── <organization-id>/                # AWS Organization ID
     │       ├── ous/                          # organizational units metadata
     │       ├── rcps/                         # resource control policies
+    │       ├── s3-policies/                  # S3 policies
     │       ├── scps/                         # service control policies
     │       └── ....json                      # different metadata about the org such as accounts, or structure
     └── indexes/                              # search indexes for fast lookups
@@ -114,11 +115,10 @@ aws/                                          # always `aws` for now, may add ot
 ```
 
 - **Accounts**: Under `accounts/`, each account directory contains:
-
   - **Resource folders**: Nested by `<service-name>/<region>/<resource-type>/<resource-id>/`, each holding `metadata.json` and `data.json`.
   - **RAM**: A `ram/` folder with JSON files (`<resourceArn>.json`) for Resource Access Manager shares.
 
-- **Organizations**: Under `organizations/`, each org directory includes `accounts.json` (listing account IDs) and subfolders for `ous/`, `rcps/`, and `scps/` containing respective metadata.
+- **Organizations**: Under `organizations/`, each org directory includes `accounts.json` (listing account IDs) and subfolders for `ous/`, `rcps/`, `s3-policies/`, and `scps/` containing respective metadata.
 
 - **Indexes**: The `indexes/` folder contains JSON files that serve as search indexes for faster lookups, such as mapping buckets to accounts or accounts to organizations.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,10 @@ export { loadConfigFiles } from './config/configFile.js'
 export { downloadData } from './download/download.js'
 export { index } from './index/index.js'
 export { mergeSqliteDatabases } from './mergeSqlite/mergeSqlite.js'
-export type { AwsIamStore, StorageClientOptions } from './persistence/AwsIamStore.js'
+export type {
+  AwsIamStore,
+  OrganizationPolicyType,
+  StorageClientOptions
+} from './persistence/AwsIamStore.js'
 export { createInMemoryStorageClient, createStorageClient } from './persistence/util.js'
 export type { allServices, AwsService } from './services.js'

--- a/src/persistence/AwsIamStore.ts
+++ b/src/persistence/AwsIamStore.ts
@@ -50,7 +50,7 @@ export interface ResourceTypeParts {
   metadata?: Record<string, string>
 }
 
-export type OrganizationPolicyType = 'scps' | 'rcps'
+export type OrganizationPolicyType = 'scps' | 'rcps' | 's3-policies'
 
 /**
  * An interface for persisting AWS resource metadata.

--- a/src/persistence/file/FileSystemAwsIamStore.test.ts
+++ b/src/persistence/file/FileSystemAwsIamStore.test.ts
@@ -809,6 +809,27 @@ describe('FileSystemAwsIamStore', () => {
       )
     })
 
+    it('should save organization s3 policy metadata', async () => {
+      // Given a specific organization ID and S3 policy type
+      const data = JSON.stringify({ Version: '2012-10-17', Statement: [] })
+      const writeFileSpy = vi.spyOn(mockFsAdapter, 'writeFile').mockResolvedValue()
+
+      // When metadata is saved
+      await store.saveOrganizationPolicyMetadata(
+        'o-12345',
+        's3-policies',
+        'p-12345678',
+        'policy',
+        data
+      )
+
+      // Then the S3 policies directory should be used
+      expect(writeFileSpy).toHaveBeenCalledWith(
+        '/base/folder/aws/aws/organizations/o-12345/s3-policies/p-12345678/policy.json',
+        data
+      )
+    })
+
     it('should delete the organization policy metadata file if data is empty', async () => {
       for (const emptyValue of ['', '   ', '{}', '[]', undefined, null, {}, []]) {
         // Given a specific organization ID and policy type

--- a/src/persistence/sqlite/SqliteAwsIamStore.test.ts
+++ b/src/persistence/sqlite/SqliteAwsIamStore.test.ts
@@ -619,12 +619,23 @@ describe('SqliteAwsIamStore', () => {
       await store.saveOrganizationPolicyMetadata('o-1234567890', 'rcps', 'p-789', 'metadata', {
         name: 'Policy3'
       })
+      await store.saveOrganizationPolicyMetadata(
+        'o-1234567890',
+        's3-policies',
+        'p-s3policy',
+        'metadata',
+        {
+          name: 'S3Policy'
+        }
+      )
 
       const scps = await store.listOrganizationPolicies('o-1234567890', 'scps')
       const rcps = await store.listOrganizationPolicies('o-1234567890', 'rcps')
+      const s3Policies = await store.listOrganizationPolicies('o-1234567890', 's3-policies')
 
       expect(scps.sort()).toEqual(['p-123', 'p-456'])
       expect(rcps).toEqual(['p-789'])
+      expect(s3Policies).toEqual(['p-s3policy'])
     })
 
     it('normalizes case for organization policy operations', async () => {

--- a/src/syncs/organizations/organizations.test.ts
+++ b/src/syncs/organizations/organizations.test.ts
@@ -1,0 +1,269 @@
+import {
+  DescribeOrganizationCommand,
+  DescribePolicyCommand,
+  DescribeResourcePolicyCommand,
+  ListAccountsForParentCommand,
+  ListDelegatedAdministratorsCommand,
+  ListDelegatedServicesForAccountCommand,
+  ListOrganizationalUnitsForParentCommand,
+  ListPoliciesCommand,
+  ListPoliciesForTargetCommand,
+  ListRootsCommand,
+  ListTagsForResourceCommand,
+  OrganizationsClient,
+  PolicyType,
+  PolicyTypeStatus
+} from '@aws-sdk/client-organizations'
+import { mockClient } from 'aws-sdk-client-mock'
+import { afterEach, describe, expect, it } from 'vitest'
+import { AwsClientPool } from '../../aws/ClientPool.js'
+import { type AwsCredentialProviderWithMetaData } from '../../aws/coreAuth.js'
+import { FileSystemAwsIamStore } from '../../persistence/file/FileSystemAwsIamStore.js'
+import { InMemoryPathBasedPersistenceAdapter } from '../../persistence/InMemoryPathBasedPersistenceAdapter.js'
+import { OrganizationSync } from './organizations.js'
+
+const organizationsMock = mockClient(OrganizationsClient)
+const accountId = '111111111111'
+const organizationId = 'o-example'
+const rootId = 'r-root'
+const childOuId = 'ou-root-child'
+
+const credentials: AwsCredentialProviderWithMetaData = {
+  accountId,
+  partition: 'aws',
+  cacheKey: 'test-credentials',
+  provider: async () => ({
+    accessKeyId: 'test-access-key-id',
+    secretAccessKey: 'test-secret-access-key'
+  })
+}
+
+function createStore(): FileSystemAwsIamStore {
+  return new FileSystemAwsIamStore(
+    '/base/folder',
+    'aws',
+    '/',
+    new InMemoryPathBasedPersistenceAdapter()
+  )
+}
+
+async function executeOrganizationSync(
+  store: FileSystemAwsIamStore,
+  writeOnly = false
+): Promise<void> {
+  const clientPool = new AwsClientPool()
+  await OrganizationSync.execute(accountId, 'us-east-1', credentials, store, undefined, {
+    clientPool,
+    writeOnly,
+    workerPool: {} as any
+  })
+  clientPool.clear()
+}
+
+describe('OrganizationSync', () => {
+  afterEach(() => {
+    organizationsMock.reset()
+  })
+
+  it('collects enabled organization S3 policies and attachments', async () => {
+    //Given an organization with S3 policies enabled and attached to the root, child OU, and account
+    const store = createStore()
+    setupOrganizationResponses({ s3PoliciesEnabled: true })
+
+    organizationsMock.on(ListPoliciesForTargetCommand).callsFake((input) => {
+      return {
+        Policies: [
+          {
+            Id: `p-${input.TargetId}-${input.Filter}`,
+            Arn: `arn:aws:organizations::${accountId}:policy/${organizationId}/${input.Filter}/p-${input.TargetId}`
+          }
+        ]
+      }
+    })
+    organizationsMock.on(ListPoliciesCommand).resolves({ Policies: [] })
+    organizationsMock.on(ListPoliciesCommand, { Filter: PolicyType.S3_POLICY }).resolves({
+      Policies: [
+        {
+          Id: 'p-s3-policy',
+          Arn: `arn:aws:organizations::${accountId}:policy/${organizationId}/s3_policy/p-s3-policy`,
+          Name: 'LimitBucketSharing',
+          Description: 'Synthetic S3 policy',
+          AwsManaged: false
+        }
+      ]
+    })
+    organizationsMock.on(DescribePolicyCommand, { PolicyId: 'p-s3-policy' }).resolves({
+      Policy: {
+        Content: JSON.stringify({
+          Version: '2012-10-17',
+          Statement: [{ Effect: 'Deny', Action: 's3:PutBucketPolicy', Resource: '*' }]
+        })
+      }
+    })
+    organizationsMock.on(ListTagsForResourceCommand, { ResourceId: 'p-s3-policy' }).resolves({
+      Tags: [{ Key: 'policy-family', Value: 's3' }]
+    })
+
+    //When the organization sync runs
+    await executeOrganizationSync(store)
+
+    //Then S3 policy attachments should be stored for accounts and OUs
+    const accounts = await store.getOrganizationMetadata<Record<string, any>>(
+      organizationId,
+      'accounts'
+    )
+    const ous = await store.getOrganizationMetadata<Record<string, any>>(organizationId, 'ous')
+    expect(accounts?.[accountId].s3Policies).toEqual([
+      `arn:aws:organizations::${accountId}:policy/${organizationId}/${PolicyType.S3_POLICY}/p-${accountId}`
+    ])
+    expect(ous?.[rootId].s3Policies).toEqual([
+      `arn:aws:organizations::${accountId}:policy/${organizationId}/${PolicyType.S3_POLICY}/p-${rootId}`
+    ])
+    expect(ous?.[childOuId].s3Policies).toEqual([
+      `arn:aws:organizations::${accountId}:policy/${organizationId}/${PolicyType.S3_POLICY}/p-${childOuId}`
+    ])
+
+    //And S3 policy metadata, content, and tags should be stored under the S3 policy type
+    await expect(store.listOrganizationPolicies(organizationId, 's3-policies')).resolves.toEqual([
+      'p-s3-policy'
+    ])
+    await expect(
+      store.getOrganizationPolicyMetadata(organizationId, 's3-policies', 'p-s3-policy', 'metadata')
+    ).resolves.toEqual({
+      arn: `arn:aws:organizations::${accountId}:policy/${organizationId}/s3_policy/p-s3-policy`,
+      name: 'LimitBucketSharing',
+      description: 'Synthetic S3 policy',
+      awsManaged: false
+    })
+    await expect(
+      store.getOrganizationPolicyMetadata(organizationId, 's3-policies', 'p-s3-policy', 'policy')
+    ).resolves.toEqual({
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Deny', Action: 's3:PutBucketPolicy', Resource: '*' }]
+    })
+    await expect(
+      store.getOrganizationPolicyMetadata(organizationId, 's3-policies', 'p-s3-policy', 'tags')
+    ).resolves.toEqual({ 'policy-family': 's3' })
+
+    //And the child OU policy attachment lookups should use the child OU ID for all policy types
+    const childOuAttachmentCalls = organizationsMock
+      .commandCalls(ListPoliciesForTargetCommand)
+      .filter((call) => call.args[0].input.TargetId === childOuId)
+      .map((call) => call.args[0].input.Filter)
+    expect(childOuAttachmentCalls).toEqual([
+      PolicyType.SERVICE_CONTROL_POLICY,
+      PolicyType.RESOURCE_CONTROL_POLICY,
+      PolicyType.S3_POLICY
+    ])
+  })
+
+  it('deletes stale S3 policies when S3 policies are disabled and write-only mode is off', async () => {
+    //Given a stored S3 policy and an organization with S3 policies disabled
+    const store = createStore()
+    await store.saveOrganizationPolicyMetadata(organizationId, 's3-policies', 'p-stale', 'policy', {
+      Version: '2012-10-17',
+      Statement: []
+    })
+    setupOrganizationResponses({ s3PoliciesEnabled: false })
+    organizationsMock.on(ListPoliciesForTargetCommand).resolves({ Policies: [] })
+    organizationsMock.on(ListPoliciesCommand).resolves({ Policies: [] })
+
+    //When the organization sync runs in normal mode
+    await executeOrganizationSync(store)
+
+    //Then stale S3 policy records should be removed and attachment fields should be empty
+    await expect(store.listOrganizationPolicies(organizationId, 's3-policies')).resolves.toEqual([])
+    const accounts = await store.getOrganizationMetadata<Record<string, any>>(
+      organizationId,
+      'accounts'
+    )
+    expect(accounts?.[accountId].s3Policies).toEqual([])
+    expect(
+      organizationsMock
+        .commandCalls(ListPoliciesCommand)
+        .some((call) => call.args[0].input.Filter === PolicyType.S3_POLICY)
+    ).toBe(false)
+  })
+
+  it('keeps stale S3 policies when S3 policies are disabled and write-only mode is on', async () => {
+    //Given a stored S3 policy and an organization with S3 policies disabled
+    const store = createStore()
+    await store.saveOrganizationPolicyMetadata(organizationId, 's3-policies', 'p-stale', 'policy', {
+      Version: '2012-10-17',
+      Statement: []
+    })
+    setupOrganizationResponses({ s3PoliciesEnabled: false })
+    organizationsMock.on(ListPoliciesForTargetCommand).resolves({ Policies: [] })
+    organizationsMock.on(ListPoliciesCommand).resolves({ Policies: [] })
+
+    //When the organization sync runs in write-only mode
+    await executeOrganizationSync(store, true)
+
+    //Then stale S3 policy records should remain and disabled S3 policies should not be listed
+    await expect(store.listOrganizationPolicies(organizationId, 's3-policies')).resolves.toEqual([
+      'p-stale'
+    ])
+    expect(
+      organizationsMock
+        .commandCalls(ListPoliciesCommand)
+        .some((call) => call.args[0].input.Filter === PolicyType.S3_POLICY)
+    ).toBe(false)
+  })
+})
+
+function setupOrganizationResponses(options: { s3PoliciesEnabled: boolean }): void {
+  organizationsMock.on(DescribeOrganizationCommand).resolves({
+    Organization: {
+      Id: organizationId,
+      Arn: `arn:aws:organizations::${accountId}:organization/${organizationId}`,
+      MasterAccountArn: `arn:aws:organizations::${accountId}:account/${organizationId}/${accountId}`,
+      MasterAccountId: accountId
+    }
+  })
+  organizationsMock.on(ListRootsCommand).resolves({
+    Roots: [
+      {
+        Id: rootId,
+        Arn: `arn:aws:organizations::${accountId}:root/${organizationId}/${rootId}`,
+        Name: 'Root',
+        PolicyTypes: [
+          { Type: PolicyType.SERVICE_CONTROL_POLICY, Status: PolicyTypeStatus.ENABLED },
+          { Type: PolicyType.RESOURCE_CONTROL_POLICY, Status: PolicyTypeStatus.ENABLED },
+          {
+            Type: PolicyType.S3_POLICY,
+            Status: options.s3PoliciesEnabled ? PolicyTypeStatus.ENABLED : PolicyTypeStatus.DISABLED
+          }
+        ]
+      }
+    ]
+  })
+  organizationsMock.on(ListOrganizationalUnitsForParentCommand, { ParentId: rootId }).resolves({
+    OrganizationalUnits: [
+      {
+        Id: childOuId,
+        Arn: `arn:aws:organizations::${accountId}:ou/${organizationId}/${childOuId}`,
+        Name: 'Engineering'
+      }
+    ]
+  })
+  organizationsMock.on(ListOrganizationalUnitsForParentCommand, { ParentId: childOuId }).resolves({
+    OrganizationalUnits: []
+  })
+  organizationsMock.on(ListAccountsForParentCommand, { ParentId: rootId }).resolves({
+    Accounts: [
+      {
+        Id: accountId,
+        Arn: `arn:aws:organizations::${accountId}:account/${organizationId}/${accountId}`
+      }
+    ]
+  })
+  organizationsMock.on(ListAccountsForParentCommand, { ParentId: childOuId }).resolves({
+    Accounts: []
+  })
+  organizationsMock.on(ListTagsForResourceCommand).resolves({ Tags: [] })
+  organizationsMock.on(ListDelegatedAdministratorsCommand).resolves({ DelegatedAdministrators: [] })
+  organizationsMock.on(ListDelegatedServicesForAccountCommand).resolves({ DelegatedServices: [] })
+  organizationsMock.on(DescribeResourcePolicyCommand).rejects({
+    name: 'ResourcePolicyNotFoundException'
+  })
+}

--- a/src/syncs/organizations/organizations.ts
+++ b/src/syncs/organizations/organizations.ts
@@ -578,10 +578,12 @@ async function syncPolicies(
   enabled: boolean,
   writeOnly: boolean
 ): Promise<void> {
-  if (!enabled && !writeOnly) {
-    const existingPolicies = await storage.listOrganizationPolicies(organizationId, fileType)
-    for (const policyId of existingPolicies) {
-      await storage.deleteOrganizationPolicy(organizationId, fileType, policyId)
+  if (!enabled) {
+    if (!writeOnly) {
+      const existingPolicies = await storage.listOrganizationPolicies(organizationId, fileType)
+      for (const policyId of existingPolicies) {
+        await storage.deleteOrganizationPolicy(organizationId, fileType, policyId)
+      }
     }
     return
   }

--- a/src/syncs/organizations/organizations.ts
+++ b/src/syncs/organizations/organizations.ts
@@ -33,6 +33,7 @@ interface AccountDetails {
   ou: string
   scps: string[]
   rcps: string[]
+  s3Policies: string[]
   tags: Record<string, string> | undefined
 }
 
@@ -97,6 +98,7 @@ export const OrganizationSync: Sync = {
 
     const scpsEnabled = !!features[PolicyType.SERVICE_CONTROL_POLICY]
     const rcpsEnabled = !!features[PolicyType.RESOURCE_CONTROL_POLICY]
+    const s3PoliciesEnabled = !!features[PolicyType.S3_POLICY]
 
     const allAccounts: AccountDetailsMap = {}
     const allOus: Record<
@@ -105,6 +107,7 @@ export const OrganizationSync: Sync = {
         parent: string | undefined
         scps: string[]
         rcps: string[]
+        s3Policies: string[]
       }
     > = {}
 
@@ -123,6 +126,12 @@ export const OrganizationSync: Sync = {
         root.Id!,
         PolicyType.RESOURCE_CONTROL_POLICY,
         rcpsEnabled
+      ),
+      s3Policies: await getPoliciesForTarget(
+        organizationClient,
+        root.Id!,
+        PolicyType.S3_POLICY,
+        s3PoliciesEnabled
       )
     }
     ouDetails[root.Id!] = await getOuDetails(organizationClient, root)
@@ -150,15 +159,21 @@ export const OrganizationSync: Sync = {
             parent: key,
             scps: await getPoliciesForTarget(
               organizationClient,
-              root.Id!,
+              childId,
               PolicyType.SERVICE_CONTROL_POLICY,
               scpsEnabled
             ),
             rcps: await getPoliciesForTarget(
               organizationClient,
-              root.Id!,
+              childId,
               PolicyType.RESOURCE_CONTROL_POLICY,
               rcpsEnabled
+            ),
+            s3Policies: await getPoliciesForTarget(
+              organizationClient,
+              childId,
+              PolicyType.S3_POLICY,
+              s3PoliciesEnabled
             )
           }
           parent[key].children ||= {}
@@ -189,6 +204,12 @@ export const OrganizationSync: Sync = {
               account.Id!,
               PolicyType.RESOURCE_CONTROL_POLICY,
               rcpsEnabled
+            ),
+            s3Policies: await getPoliciesForTarget(
+              organizationClient,
+              account.Id!,
+              PolicyType.S3_POLICY,
+              s3PoliciesEnabled
             ),
             tags: accountTags
           }
@@ -257,6 +278,16 @@ export const OrganizationSync: Sync = {
       PolicyType.RESOURCE_CONTROL_POLICY,
       'rcps',
       rcpsEnabled,
+      syncOptions.writeOnly
+    )
+
+    await syncPolicies(
+      organizationId,
+      organizationClient,
+      storage,
+      PolicyType.S3_POLICY,
+      's3-policies',
+      s3PoliciesEnabled,
       syncOptions.writeOnly
     )
 
@@ -534,8 +565,9 @@ async function getPoliciesForTarget(
  * @param organizationClient the OrganizationsClient to use
  * @param storage the AwsIamStore to use for persistence
  * @param policyType the type of policy to sync (e.g., SERVICE_CONTROL_POLICY, RESOURCE_CONTROL_POLICY)
- * @param fileType the type of policy file to sync to storage (e.g., 'scps', 'rcps')
+ * @param fileType the type of policy file to sync to storage (e.g., 'scps', 'rcps', 's3-policies')
  * @param enabled whether the policy type is enabled in the organization
+ * @param writeOnly whether to skip deleting stale policies from storage
  */
 async function syncPolicies(
   organizationId: string,


### PR DESCRIPTION
## Summary

- Collect AWS Organizations S3 policies when the root policy type is enabled
- Store organization S3 policy metadata/content/tags under `s3-policies`
- Add `s3Policies` attachment lists for organization root, OUs, and accounts
- Fix child OU SCP/RCP attachment lookups to query the child OU ID instead of the root ID

## Tests

- `npm run build`
- `npx vitest --run src/syncs/organizations/organizations.test.ts src/persistence/file/FileSystemAwsIamStore.test.ts src/persistence/sqlite/SqliteAwsIamStore.test.ts`
- `npm test`
- `git diff --check`

Note: `npm run format-check` still reports pre-existing formatting warnings in unchanged files:
- `src/aws/coreAuth.ts`
- `src/persistence/InMemoryPathBasedPersistenceAdapter.ts`

## Reviews

- Claude implementation review: approved, no blocking issues
- Current-model implementation review: approved, no blocking issues