### PR TITLE
feat: collect Lambda function alias policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ If you prefer, you can configure iam-collect to pull data from AWS Config instea
 | kinesis           | Data Streams                      | name, encryption type, key id, policy, tags                                                                                         |
 | kms               | Keys                              | id, policy, tags                                                                                                                    |
 | lambda            | Functions                         | name, role, tags, policy                                                                                                            |
+| lambda            | Function Aliases                  | name, role, alias, version, policy                                                                                                  |
 | lambda            | Layer Versions                    | name, version, policy                                                                                                               |
 | ram               | Shared Resources                  | resource shares, resource policy                                                                                                    |
 | s3                | Access Points                     | name, bucket, bucket account, policy, block public access configuration, network origin, vpc, alias, endpoints                      |

--- a/docs/AwsConfig.md
+++ b/docs/AwsConfig.md
@@ -53,6 +53,7 @@ If your dataSource is AWS Config, iam-collect skips resource types that are not 
 | kinesis           | Data Streams                      | ❌               |                                                               |
 | kms               | Keys                              | ✅               | AWS::KMS::Key                                                 |
 | lambda            | Functions                         | ✅               | AWS::Lambda::Function                                         |
+| lambda            | Function Aliases                  | ❌               |                                                               |
 | lambda            | Layer Versions                    | ❌               |                                                               |
 | ram               | Shared Resources                  | ❌               |                                                               |
 | s3                | Access Points                     | ✅               | AWS::S3::AccessPoint                                          |

--- a/src/aws/collect-policy.json
+++ b/src/aws/collect-policy.json
@@ -59,6 +59,7 @@
         "kms:ListResourceTags",
         "lambda:GetLayerVersionPolicy",
         "lambda:GetPolicy",
+        "lambda:ListAliases",
         "lambda:ListFunctions",
         "lambda:ListLayerVersions",
         "lambda:ListLayers",

--- a/src/awsConfigClients/clients/AwsConfigLambdaClient.ts
+++ b/src/awsConfigClients/clients/AwsConfigLambdaClient.ts
@@ -2,6 +2,7 @@ import {
   GetLayerVersionPolicyCommand,
   GetPolicyCommand,
   LambdaClient,
+  ListAliasesCommand,
   ListFunctionsCommand,
   ListLayersCommand,
   ListLayerVersionsCommand,
@@ -19,9 +20,9 @@ import {
 /**
  * AWS Config-based Lambda client implementation
  *
- * Lambda Layers Only:
- * Since policies are not available in AWS Config for Lambda Layers, this client provides limited functionality
- * and returns empty results for all Lambda Layer operations.
+ * Lambda Layers and Aliases:
+ * Since policies are not available in AWS Config for Lambda Layers or aliases, this client provides limited
+ * functionality and returns empty results for those operations.
  */
 export class AwsConfigLambdaClient extends AbstractClient<AwsConfigClientContext> {
   static readonly clientName = LambdaClient.name
@@ -42,6 +43,7 @@ export class AwsConfigLambdaClient extends AbstractClient<AwsConfigClientContext
   protected registerCommands(): void {
     this.registerCommand(AwsConfigGetLayerVersionPolicyCommand)
     this.registerCommand(AwsConfigGetPolicyCommand)
+    this.registerCommand(AwsConfigListAliasesCommand)
     this.registerCommand(AwsConfigListFunctionsCommand)
     this.registerCommand(AwsConfigListLayersCommand)
     this.registerCommand(AwsConfigListLayerVersionsCommand)
@@ -81,6 +83,20 @@ const AwsConfigGetPolicyCommand = awsConfigCommand({
     return {
       Policy: supplementaryConfiguration?.Policy,
       RevisionId: configuration?.revisionId
+    }
+  }
+})
+
+/**
+ * Config-based implementation of Lambda ListAliasesCommand
+ * Returns an empty list since aliases and their policies are not tracked separately in Config
+ */
+const AwsConfigListAliasesCommand = awsConfigCommand({
+  command: ListAliasesCommand,
+  execute: async (input, context) => {
+    return {
+      Aliases: [],
+      NextMarker: undefined
     }
   }
 })

--- a/src/syncs/lambda/lambda.test.ts
+++ b/src/syncs/lambda/lambda.test.ts
@@ -1,0 +1,132 @@
+import {
+  GetPolicyCommand,
+  LambdaClient,
+  ListAliasesCommand,
+  ListFunctionsCommand,
+  ListTagsCommand
+} from '@aws-sdk/client-lambda'
+import { mockClient } from 'aws-sdk-client-mock'
+import { afterEach, describe, expect, it } from 'vitest'
+import { AwsClientPool } from '../../aws/ClientPool.js'
+import { type AwsCredentialProviderWithMetaData } from '../../aws/coreAuth.js'
+import { createInMemoryStorageClient } from '../../persistence/util.js'
+import { LambdaSync } from './lambda.js'
+
+const lambdaMock = mockClient(LambdaClient)
+const accountId = '111111111111'
+const region = 'us-east-1'
+const functionArn = `arn:aws:lambda:${region}:${accountId}:function:test-function`
+const credentials: AwsCredentialProviderWithMetaData = {
+  accountId,
+  partition: 'aws',
+  cacheKey: 'test-credentials',
+  provider: async () => ({
+    accessKeyId: 'test-access-key-id',
+    secretAccessKey: 'test-secret-access-key'
+  })
+}
+
+const workerPool = {
+  enqueueAll: (jobs: any[]) =>
+    jobs.map(async (job) => {
+      try {
+        return {
+          status: 'fulfilled',
+          value: await job.execute({ workerId: 1, properties: job.properties }),
+          properties: job.properties
+        }
+      } catch (reason) {
+        return { status: 'rejected', reason, properties: job.properties }
+      }
+    })
+} as any
+
+describe('LambdaSync', () => {
+  afterEach(() => {
+    lambdaMock.reset()
+  })
+
+  it('collects function alias policies under their qualified ARNs', async () => {
+    //Given a Lambda function with aliases returned across multiple pages
+    const store = createInMemoryStorageClient()
+    const staleAliasArn = `${functionArn}:stale`
+    await store.saveResourceMetadata(accountId, staleAliasArn, 'metadata', {
+      arn: staleAliasArn,
+      name: 'test-function',
+      alias: 'stale'
+    })
+
+    lambdaMock.on(ListFunctionsCommand).resolves({
+      Functions: [{ FunctionName: 'test-function', FunctionArn: functionArn, Role: 'test-role' }]
+    })
+    lambdaMock.on(ListTagsCommand).resolves({ Tags: { environment: 'test' } })
+    lambdaMock
+      .on(GetPolicyCommand, { FunctionName: 'test-function' })
+      .resolves({ Policy: JSON.stringify({ Statement: [{ Sid: 'function-policy' }] }) })
+    lambdaMock.on(ListAliasesCommand).callsFake((input) => {
+      if (input.Marker === 'next-page') {
+        return {
+          Aliases: [
+            {
+              AliasArn: `${functionArn}:beta`,
+              Name: 'beta',
+              FunctionVersion: '3'
+            }
+          ]
+        }
+      }
+      return {
+        Aliases: [
+          {
+            AliasArn: `${functionArn}:prod`,
+            Name: 'prod',
+            FunctionVersion: '2'
+          }
+        ],
+        NextMarker: 'next-page'
+      }
+    })
+    lambdaMock
+      .on(GetPolicyCommand, { FunctionName: 'test-function', Qualifier: 'prod' })
+      .resolves({ Policy: JSON.stringify({ Statement: [{ Sid: 'prod-policy' }] }) })
+    lambdaMock
+      .on(GetPolicyCommand, { FunctionName: 'test-function', Qualifier: 'beta' })
+      .resolves({ Policy: JSON.stringify({ Statement: [{ Sid: 'beta-policy' }] }) })
+
+    const clientPool = new AwsClientPool()
+
+    //When the Lambda sync runs
+    await LambdaSync.execute(accountId, region, credentials, store, undefined, {
+      clientPool,
+      workerPool,
+      writeOnly: false
+    })
+    clientPool.clear()
+
+    //Then each alias policy and identifying metadata are stored under the qualified alias ARN
+    await expect(
+      store.getResourceMetadata(accountId, `${functionArn}:prod`, 'policy')
+    ).resolves.toEqual({ Statement: [{ Sid: 'prod-policy' }] })
+    await expect(
+      store.getResourceMetadata(accountId, `${functionArn}:beta`, 'metadata')
+    ).resolves.toEqual({
+      arn: `${functionArn}:beta`,
+      role: 'test-role',
+      name: 'test-function',
+      alias: 'beta',
+      version: '3'
+    })
+
+    //And the base function remains collected while aliases that no longer exist are removed
+    await expect(store.getResourceMetadata(accountId, functionArn, 'policy')).resolves.toEqual({
+      Statement: [{ Sid: 'function-policy' }]
+    })
+    await expect(store.listResourceMetadata(accountId, staleAliasArn)).resolves.toEqual([])
+
+    //And aliases are listed by function name with pagination
+    expect(lambdaMock.commandCalls(ListAliasesCommand).map((call) => call.args[0].input)).toEqual([
+      { FunctionName: 'test-function', Marker: undefined },
+      { FunctionName: 'test-function', Marker: 'next-page' }
+    ])
+  })
+})

--- a/src/syncs/lambda/lambda.test.ts
+++ b/src/syncs/lambda/lambda.test.ts
@@ -114,6 +114,7 @@ describe('LambdaSync', () => {
       role: 'test-role',
       name: 'test-function',
       alias: 'beta',
+      isAlias: 'true',
       version: '3'
     })
 

--- a/src/syncs/lambda/lambda.ts
+++ b/src/syncs/lambda/lambda.ts
@@ -158,6 +158,7 @@ async function collectAliasRecords(
         arn: alias.AliasArn,
         role: func.Role,
         name: func.FunctionName,
+        isAlias: 'true',
         alias: alias.Name,
         version: alias.FunctionVersion
       },

--- a/src/syncs/lambda/lambda.ts
+++ b/src/syncs/lambda/lambda.ts
@@ -1,63 +1,171 @@
 import {
+  type FunctionConfiguration,
   GetLayerVersionPolicyCommand,
   GetPolicyCommand,
   LambdaClient,
+  ListAliasesCommand,
   ListFunctionsCommand,
   ListLayersCommand,
   ListLayerVersionsCommand,
   ListTagsCommand
 } from '@aws-sdk/client-lambda'
-import { runAndCatch404, runAndCatchAccessDeniedWithLog } from '../../utils/client-tools.js'
+import { type Job } from '@cloud-copilot/job'
+import { log } from '@cloud-copilot/log'
+import {
+  runAndCatch404,
+  runAndCatchAccessDeniedWithLog,
+  withDnsRetry
+} from '../../utils/client-tools.js'
 import { parseIfPresent } from '../../utils/json.js'
+import { convertTagsToRecord } from '../../utils/tags.js'
 import { type DataRecord, type Sync, syncData } from '../sync.js'
-import { createResourceSyncType, createTypedSyncOperation, paginateResource } from '../typedSync.js'
+import { createResourceSyncType, paginateResource, paginateResourceConfig } from '../typedSync.js'
 
-export const LambdaSync = createTypedSyncOperation(
-  'lambda',
-  'lambdaFunctions',
-  createResourceSyncType({
-    client: LambdaClient,
-    command: ListFunctionsCommand,
-    key: 'Functions',
-    paginationConfig: {
-      inputKey: 'Marker',
-      outputKey: 'NextMarker'
+const lambdaFunctionSync = createResourceSyncType({
+  client: LambdaClient,
+  command: ListFunctionsCommand,
+  key: 'Functions',
+  paginationConfig: {
+    inputKey: 'Marker',
+    outputKey: 'NextMarker'
+  },
+  resourceTypeParts: (accountId: string, region: string) => ({
+    service: 'lambda',
+    resourceType: 'function',
+    account: accountId,
+    region: region
+  }),
+  extraFields: {
+    tags: async (client, resource) => {
+      return runAndCatch404(async () => {
+        const tagResult = await client.send(new ListTagsCommand({ Resource: resource.FunctionArn }))
+        return tagResult.Tags
+      })
     },
-    resourceTypeParts: (accountId: string, region: string) => ({
-      service: 'lambda',
-      resourceType: 'function',
-      account: accountId,
-      region: region
-    }),
-    extraFields: {
-      tags: async (client, resource) => {
-        return runAndCatch404(async () => {
-          const tagResult = await client.send(
-            new ListTagsCommand({ Resource: resource.FunctionArn })
-          )
-          return tagResult.Tags
+    policy: async (client, resource) => {
+      return runAndCatch404(async () => {
+        const policyResult = await client.send(
+          new GetPolicyCommand({ FunctionName: resource.FunctionName })
+        )
+        return parseIfPresent(policyResult.Policy)
+      })
+    }
+  },
+  tags: (func) => func.extraFields.tags,
+  arn: (func) => func.FunctionArn!,
+  results: (func) => ({
+    metadata: {
+      role: func.Role,
+      name: func.FunctionName
+    },
+    policy: func.extraFields.policy
+  })
+})
+
+export const LambdaSync: Sync = {
+  awsService: 'lambda',
+  name: 'lambdaFunctions',
+  execute: async (accountId, region, credentials, storage, endpoint, syncOptions) => {
+    const functions = await paginateResourceConfig(
+      lambdaFunctionSync,
+      credentials,
+      region,
+      endpoint,
+      syncOptions.workerPool,
+      'lambda',
+      'lambdaFunctions',
+      syncOptions.clientPool
+    )
+
+    const records: DataRecord[] = functions.map((func) => {
+      const result = lambdaFunctionSync.results(func) as DataRecord
+      result.arn = lambdaFunctionSync.arn(
+        func,
+        region,
+        credentials.accountId,
+        credentials.partition
+      )
+      result.metadata.arn = result.arn
+      result.tags = convertTagsToRecord(lambdaFunctionSync.tags(func))
+      return result
+    })
+
+    const lambdaClient = syncOptions.clientPool.client(LambdaClient, credentials, region, endpoint)
+    const aliasJobs: Job<DataRecord[], { function: FunctionConfiguration }>[] = functions.map(
+      (func) => ({
+        properties: { function: func },
+        execute: async () => collectAliasRecords(lambdaClient, func)
+      })
+    )
+    const aliasResults = await Promise.all(syncOptions.workerPool.enqueueAll(aliasJobs))
+    for (const result of aliasResults) {
+      if (result.status === 'rejected') {
+        const func = result.properties.function as FunctionConfiguration
+        log.error('Failed to collect Lambda function aliases', result.reason, {
+          functionArn: func.FunctionArn
         })
+        throw new Error(`Failed to collect aliases for Lambda function ${func.FunctionArn}`)
+      }
+      records.push(...result.value)
+    }
+
+    await syncData(
+      records,
+      storage,
+      accountId,
+      lambdaFunctionSync.resourceTypeParts(credentials.accountId, region),
+      syncOptions.writeOnly
+    )
+  }
+}
+
+async function collectAliasRecords(
+  lambdaClient: LambdaClient,
+  func: FunctionConfiguration
+): Promise<DataRecord[]> {
+  const aliases = await withDnsRetry(() =>
+    paginateResource(
+      lambdaClient,
+      ListAliasesCommand,
+      'Aliases',
+      {
+        inputKey: 'Marker',
+        outputKey: 'NextMarker'
       },
-      policy: async (client, resource) => {
-        return runAndCatch404(async () => {
-          const policyResult = await client.send(
-            new GetPolicyCommand({ FunctionName: resource.FunctionName })
+      { FunctionName: func.FunctionName }
+    )
+  )
+
+  const records: DataRecord[] = []
+  for (const alias of aliases) {
+    const policy = await withDnsRetry(() =>
+      runAndCatchAccessDeniedWithLog(alias.AliasArn!, 'lambda', 'lambdaFunctions', 'policy', () =>
+        runAndCatch404(async () => {
+          const policyResult = await lambdaClient.send(
+            new GetPolicyCommand({
+              FunctionName: func.FunctionName,
+              Qualifier: alias.Name
+            })
           )
           return parseIfPresent(policyResult.Policy)
         })
-      }
-    },
-    tags: (func) => func.extraFields.tags,
-    arn: (func) => func.FunctionArn!,
-    results: (func) => ({
+      )
+    )
+
+    records.push({
+      arn: alias.AliasArn!,
       metadata: {
+        arn: alias.AliasArn,
         role: func.Role,
-        name: func.FunctionName
+        name: func.FunctionName,
+        alias: alias.Name,
+        version: alias.FunctionVersion
       },
-      policy: func.extraFields.policy
+      policy
     })
-  })
-)
+  }
+  return records
+}
 
 export const LambdaLayerVersionsSync: Sync = {
   awsService: 'lambda',

--- a/src/syncs/sync.ts
+++ b/src/syncs/sync.ts
@@ -5,7 +5,7 @@ import { type AwsIamStore, type ResourceTypeParts } from '../persistence/AwsIamS
 import { type AwsService } from '../services.js'
 
 export interface SyncOptions {
-  workerPool: ConcurrentWorkerPool
+  workerPool: ConcurrentWorkerPool<any, any>
   writeOnly: boolean
   customConfig?: Record<string, any>
   clientPool: AwsClientPool


### PR DESCRIPTION
I noticed that iam-collect is not collecting resource policies for Lambda function _aliases_, so I've added that in this PR. Happy for you to change whatever you want as you see fit.