### PR TITLE
fix: run PR checks with pull_request trigger

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,7 +1,7 @@
 name: 'Lint PR'
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -11,12 +11,13 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:
@@ -28,8 +29,6 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -48,8 +47,6 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -75,7 +72,6 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Set up Python


### PR DESCRIPTION
## Summary

- switch PR checks from `pull_request_target` to `pull_request` so fork PR code can be checked out safely
- keep `workflow_dispatch` support for dependency-update validation
- remove explicit PR head SHA checkout and rely on `actions/checkout` defaults for each event

## Why

Fork PR checks were failing before running because GitHub refuses to check out fork code in a `pull_request_target` workflow without opting into unsafe checkout behavior. Build/test/format/static scan jobs should run under the restricted `pull_request` context instead.

## Validation

- Not run locally; workflow-only change.